### PR TITLE
Patch

### DIFF
--- a/lib/openssl/nonblock.rb
+++ b/lib/openssl/nonblock.rb
@@ -1,2 +1,4 @@
 require 'openssl'
-require File.dirname(__FILE__) + '/../openssl_nonblock'
+if RUBY_VERSION < '1.9.2'
+    require File.dirname(__FILE__) + '/../openssl_nonblock'
+end


### PR DESCRIPTION
Without it i have an error like:
internal:lib/rubygems/custom_require:29:in `require': /usr/lib/ruby/gems/1.9.1/gems/openssl-nonblock-0.2.1/lib/openssl_nonblock.so: undefined symbol: Init_openssl_nonblock - /usr/lib/ruby/gems/1.9.1/gems/openssl-nonblock-0.2.1/lib/openssl_nonblock.so (LoadError)
